### PR TITLE
Handle null responses without throwing a TypeError

### DIFF
--- a/regenerate-thumbnails.php
+++ b/regenerate-thumbnails.php
@@ -295,6 +295,12 @@ class RegenerateThumbnails {
 					url: ajaxurl,
 					data: { action: "regeneratethumbnail", id: id },
 					success: function( response ) {
+						if ( response === null ) {
+							response = new Object;
+							response.success = false;
+							response.error = "The resize request was abnormally terminated (ID " + id + "). This is likely due to the image exceeding available memory.";
+						}
+
 						if ( response.success ) {
 							RegenThumbsUpdateStatus( id, true, response );
 						}


### PR DESCRIPTION
A simple JS patch to avoid throwing a TypeError when response is null.
