### PR TITLE
Use the latest "Requires PHP" header field

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@ Donate link: http://www.viper007bond.com/donate/
 Tags: thumbnail, thumbnails
 Requires at least: 3.2
 Tested up to: 4.9
+Requires PHP: 5.2.4
 Stable tag: trunk
 
 Allows you to regenerate your thumbnails after changing the thumbnail sizes.


### PR DESCRIPTION
Add the new "Requires PHP" header field to set the minimum required PHP version for the plugin.

See more info at: https://generatewp.com/minimum-required-php-version-plugins/