### PR TITLE
Re-enable deleting unregistered sizes along with a warning.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -62,6 +62,10 @@ The source code for this plugin is available on [GitHub](https://github.com/Vipe
 
 == ChangeLog ==
 
+= Version 3.1.0 =
+
+* Re-enable the ability to delete old, unregistered thumbnail files. It was temporarily disabled until I was more confident in the separate update post functionality but fixing that is turning out to be rather complicated.
+
 = Version 3.0.2 =
 
 * Fix slowdown in certain cases in the media library.

--- a/regenerate-thumbnails.php
+++ b/regenerate-thumbnails.php
@@ -5,7 +5,7 @@
 Plugin Name:  Regenerate Thumbnails
 Description:  Regenerate the thumbnails for one or more of your image uploads. Useful when changing their sizes or your theme.
 Plugin URI:   https://alex.blog/wordpress-plugins/regenerate-thumbnails/
-Version:      3.0.2
+Version:      3.1.0
 Author:       Alex Mills (Viper007Bond)
 Author URI:   https://alex.blog/
 Text Domain:  regenerate-thumbnails
@@ -43,7 +43,7 @@ class RegenerateThumbnails {
 	 *
 	 * @var string
 	 */
-	public $version = '3.0.2';
+	public $version = '3.1.0';
 
 	/**
 	 * The menu ID of this plugin, as returned by add_management_page().

--- a/regenerate-thumbnails.php
+++ b/regenerate-thumbnails.php
@@ -211,7 +211,7 @@ class RegenerateThumbnails {
 					'regenerateThumbnails'                      => __( 'Regenerate Thumbnails', 'regenerate-thumbnails' ),
 					'loading'                                   => __( 'Loading…', 'regenerate-thumbnails' ),
 					'onlyRegenerateMissingThumbnails'           => __( 'Skip regenerating existing correctly sized thumbnails (faster).', 'regenerate-thumbnails' ),
-					'deleteOldThumbnails'                       => __( "Delete thumbnail files for old unregistered sizes in order to free up server space. You risk broken images if you do this so it's strongly recommended that you update the content of posts to reduce the risk.", 'regenerate-thumbnails' ),
+					'deleteOldThumbnails'                       => __( "Delete thumbnail files for old unregistered sizes in order to free up server space. This may result in broken images in your posts and pages.", 'regenerate-thumbnails' ),
 					'thumbnailSizeItemWithCropMethodNoFilename' => __( '<strong>{label}:</strong> {width}×{height} pixels ({cropMethod})', 'regenerate-thumbnails' ),
 					'thumbnailSizeItemWithCropMethod'           => __( '<strong>{label}:</strong> {width}×{height} pixels ({cropMethod}) <code>{filename}</code>', 'regenerate-thumbnails' ),
 					'thumbnailSizeItemWithoutCropMethod'        => __( '<strong>{label}:</strong> {width}×{height} pixels <code>{filename}</code>', 'regenerate-thumbnails' ),

--- a/src/routes/RegenerateSingle.vue
+++ b/src/routes/RegenerateSingle.vue
@@ -40,7 +40,7 @@
 				</label>
 			</p>
 
-			<p style="display:none">
+			<p>
 				<label>
 					<input
 						type="checkbox"
@@ -191,7 +191,7 @@
 			},
 			checkUpdatePosts(event) {
 				if (event.target.checked) {
-					document.getElementById('regenthumbs-regenopt-updateposts').checked = true;
+					//document.getElementById('regenthumbs-regenopt-updateposts').checked = true;
 				}
 			},
 		},

--- a/src/routes/subpages/HomeIntro.vue
+++ b/src/routes/subpages/HomeIntro.vue
@@ -27,7 +27,7 @@
 			</label>
 		</p>
 
-		<p style="display:none">
+		<p>
 			<label>
 				<input
 					type="checkbox"
@@ -179,7 +179,7 @@
 
 				// Check the update posts checkbox when the delete checkbox is checked
 				if ('checkboxDeleteOld' === prop && this[prop]) {
-					this.checkboxUpdatePosts = true;
+					//this.checkboxUpdatePosts = true;
 				}
 			},
 		},


### PR DESCRIPTION
Reliably updating posts to use new URLs is going to a big can of edge cases. Instead of waiting for that to (ever) be re-released, let's just re-allow deletion of old sizes along with a warning.