### PR TITLE
Avoid a "divide by zero" error here

### DIFF
--- a/includes/class-regeneratethumbnails-rest-controller.php
+++ b/includes/class-regeneratethumbnails-rest-controller.php
@@ -241,6 +241,10 @@ class RegenerateThumbnails_REST_Controller extends WP_REST_Controller {
 		$page     = $request->get_param( 'page' );
 		$per_page = $request->get_param( 'per_page' );
 
+		if ( 0 == $per_page ) {
+			$per_page = 10;
+		}
+
 		$featured_image_ids = $wpdb->get_results( $wpdb->prepare(
 			"SELECT SQL_CALC_FOUND_ROWS meta_value AS id FROM {$wpdb->postmeta} WHERE meta_key = '_thumbnail_id' GROUP BY meta_value ORDER BY MIN(meta_id) LIMIT %d OFFSET %d",
 			$per_page,


### PR DESCRIPTION
$per_page is used later in a divide operation and while it's unlikely to be 0 it's better to be safe and set it to some useful default if it is 0.