### PR TITLE
Don't attempt to regenerate SVGs

### DIFF
--- a/includes/class-regeneratethumbnails-rest-controller.php
+++ b/includes/class-regeneratethumbnails-rest-controller.php
@@ -141,6 +141,10 @@ class RegenerateThumbnails_REST_Controller extends WP_REST_Controller {
 
 		$args['post_mime_type'] = array();
 		foreach ( get_allowed_mime_types() as $mime_type ) {
+			if ( 'image/svg+xml' === $mime_type ) {
+				continue;
+			}
+
 			if ( 'application/pdf' == $mime_type || 'image/' == substr( $mime_type, 0, 6 ) ) {
 				$args['post_mime_type'][] = $mime_type;
 			}


### PR DESCRIPTION
Depending on settings, SVG files were being deleted when thumbnails were regenerated.

## Steps to Reproduce
1. Install the "SVG Support" plugin.
2. Upload some SVG files as well as other image files to the media library.
3. Add the following to theme's `functions.php` - `add_image_size( 'test-only', 666, 666, ['center', 'center'] );`
4. In _Tools_ > _Regenerate Thumbnails_, uncheck both checkboxes and regenerate thumbnails. Depending on the dimensions of the images that were uploaded, new thumbnails should be generated for each non-SVG image that are roughly 666x666.
5. Comment out the code added in step 3.
6. In _Tools_ > _Regenerate Thumbnails_, **uncheck** the _Skip_ checkbox and **check** the _Delete_ checkbox. Regenerate thumbnails.
6. Ensure the new thumbnails that were generated in step 4 are deleted, but that the SVGs are not.

Reported at https://wordpress.org/support/topic/all-svg-files-were-removed-after-plugin-work/.