### PR TITLE
Fix tests and bump supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,71 +20,17 @@ addons:
 # Test against these versions of PHP.
 # Some additional PHP versions are also included in the matrix below.
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - '7.0'
   - 7.1
   - 7.2
   - 7.3
-  - nightly
 
 # Test against these versions of WordPress.
 env:
-  - WP_VERSION=4.7 # Plugin minimum version
-  - WP_VERSION=4.8
-  - WP_VERSION=4.9
+  - WP_VERSION=5.3 # Plugin minimum version
+  - WP_VERSION=5.4
   - WP_VERSION=latest
-  - WP_VERSION=nightly
-
-# Some additional environments to test:
-#   * PHP 5.2 and 5.3 require precise not trusty
-#   * PHP_CodeSniffer
-matrix:
-  include:
-  - php: 5.2
-    dist: precise
-    env: WP_VERSION=4.7
-  - php: 5.2
-    dist: precise
-    env: WP_VERSION=4.8
-  - php: 5.2
-    dist: precise
-    env: WP_VERSION=latest
-  - php: 5.2
-    dist: precise
-    env: WP_VERSION=nightly
-  - php: 5.3
-    dist: precise
-    env: WP_VERSION=4.7
-  - php: 5.3
-    dist: precise
-    env: WP_VERSION=4.8
-  - php: 5.3
-    dist: precise
-    env: WP_VERSION=latest
-  - php: 5.3
-    dist: precise
-    env: WP_VERSION=nightly
-  exclude: # PHP 7.x doesn't play nice with older versions of WordPress and/or PHPUnit
-  - php: '7.0'
-    env: WP_VERSION=4.7
-  - php: 7.1
-    env: WP_VERSION=4.7
-  - php: 7.2
-    env: WP_VERSION=4.7
-  - php: 7.3
-    env: WP_VERSION=4.7
-  - php: 7.3
-    env: WP_VERSION=4.8
-  - php: 7.3
-    env: WP_VERSION=4.9
-  - php: nightly
-    env: WP_VERSION=4.7
-  - php: nightly
-    env: WP_VERSION=4.8
-  - php: nightly
-    env: WP_VERSION=4.9
+  - WP_VERSION=trunk
 
 before_script:
   - |

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Regenerate Thumbnails ===
 Contributors: Viper007Bond
 Tags: thumbnail, thumbnails, post thumbnail, post thumbnails
-Requires at least: 4.7
-Tested up to: 5.4
-Requires PHP: 5.2.4
+Requires at least: 5.3
+Tested up to: 5.5
+Requires PHP: 7.0
 Stable tag: 3.1.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/test-regenerator.php
+++ b/tests/test-regenerator.php
@@ -241,9 +241,9 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 
 		// Verify that the new custom thumbnails were made correctly by this plugin
 		foreach ( $expected_custom_thumbnail_sizes as $size => $dims ) {
-			$this->assertFileExists( $upload_dir . "wordpress-gsoc-flyer-pdf-{$dims[0]}x{$dims[1]}.jpg" );
-			$this->assertEquals( $dims[0], $new_metadata['sizes'][ $size ]['width'] );
-			$this->assertEquals( $dims[1], $new_metadata['sizes'][ $size ]['height'] );
+			$this->assertFileExists( $upload_dir . "wordpress-gsoc-flyer-pdf-{$dims[0]}x{$dims[1]}.jpg", 'File exists' );
+			$this->assertEquals( $dims[0], $new_metadata['sizes'][ $size ]['width'], 'Image width' );
+			$this->assertEquals( $dims[1], $new_metadata['sizes'][ $size ]['height'], 'Image height' );
 		}
 	}
 
@@ -541,6 +541,22 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 					'filename'   => '33772-1024x576.jpg',
 					'fileexists' => true,
 				),
+				array(
+					'label'      => '1536x1536',
+					'width'      => 1536,
+					'height'     => 1536,
+					'crop'       => false,
+					'filename'   => '33772-1536x864.jpg',
+					'fileexists' => true,
+				),
+				array(
+					'label'      => '2048x2048',
+					'width'      => 2048,
+					'height'     => 2048,
+					'crop'       => false,
+					'filename'   => false,
+					'fileexists' => false,
+				),
 			),
 			'unregistered_sizes' => array(),
 		);
@@ -691,16 +707,25 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 				'filename'   => '33772-1500x844.jpg',
 				'fileexists' => false,
 			),
+			array(
+				'label'      => '1536x1536',
+				'width'      => 1536,
+				'height'     => 1536,
+				'crop'       => false,
+				'filename'   => '33772-1536x864.jpg',
+				'fileexists' => true,
+			),
+			array(
+				'label'      => '2048x2048',
+				'width'      => 2048,
+				'height'     => 2048,
+				'crop'       => false,
+				'filename'   => false,
+				'fileexists' => false,
+			),
 		);
 
 		$expected_statuses['unregistered_sizes'] = array(
-			array(
-				'label'      => sprintf( __( '%s (old)', 'regenerate-thumbnails' ), 'thumbnail' ),
-				'width'      => 150,
-				'height'     => 150,
-				'filename'   => '33772-150x150.jpg',
-				'fileexists' => true,
-			),
 			array(
 				'label'      => sprintf( __( '%s (old)', 'regenerate-thumbnails' ), 'medium' ),
 				'width'      => 300,
@@ -709,17 +734,24 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 				'fileexists' => true,
 			),
 			array(
-				'label'      => sprintf( __( '%s (old)', 'regenerate-thumbnails' ), 'medium_large' ),
-				'width'      => 768,
-				'height'     => 432,
-				'filename'   => '33772-768x432.jpg',
-				'fileexists' => true,
-			),
-			array(
 				'label'      => sprintf( __( '%s (old)', 'regenerate-thumbnails' ), 'large' ),
 				'width'      => 1024,
 				'height'     => 576,
 				'filename'   => '33772-1024x576.jpg',
+				'fileexists' => true,
+			),
+			array(
+				'label'      => sprintf( __( '%s (old)', 'regenerate-thumbnails' ), 'thumbnail' ),
+				'width'      => 150,
+				'height'     => 150,
+				'filename'   => '33772-150x150.jpg',
+				'fileexists' => true,
+			),
+			array(
+				'label'      => sprintf( __( '%s (old)', 'regenerate-thumbnails' ), 'medium_large' ),
+				'width'      => 768,
+				'height'     => 432,
+				'filename'   => '33772-768x432.jpg',
 				'fileexists' => true,
 			),
 		);


### PR DESCRIPTION
See https://github.com/Automattic/regenerate-thumbnails/pull/111

I'm not sure whether it is safe to bump support versions here, given the large userbase for this plugin.