### PR TITLE
Don't overwrite 'All X Attachment' button label with featured images count

### DIFF
--- a/src/routes/subpages/HomeIntro.vue
+++ b/src/routes/subpages/HomeIntro.vue
@@ -153,9 +153,6 @@
 				context  : this
 			})
 				.done((data, textStatus, jqXHR) => {
-					this.ButtonAllText = this.regenerateThumbnails.l10n.Home.RegenerateThumbnailsForAllXAttachments.formatUnicorn({
-						'attachmentCount': jqXHR.getResponseHeader('x-wp-total').toLocaleString(),
-					});
 
 					if (jqXHR.getResponseHeader('x-wp-total') < 1) {
 						this.usingFeaturedImages = false;


### PR DESCRIPTION
Fixes #114

### Changes proposed in this Pull Request

- Fix featured image count request changing all attachment count button label

### Testing instructions

* Build assets (`npm run build`)
* Open WP-Admin > Tools > Regenerate thumbnails
* Make sure the text on `Regenerate Thumbnails For All {attachmentCount} Attachments` button matches the image attachment count in the media library (more or less), instead of just the featured images count
