### PR TITLE
Fix issue preventing regeneration of PDF attachment thumbnails, refs #94

### DIFF
--- a/includes/class-regeneratethumbnails-regenerator.php
+++ b/includes/class-regeneratethumbnails-regenerator.php
@@ -127,7 +127,7 @@ class RegenerateThumbnails_Regenerator {
 			return $this->fullsizepath;
 		}
 
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
+		if ( function_exists( 'wp_get_original_image_path' ) && wp_attachment_is_image( $this->attachment->ID ) ) {
 			$this->fullsizepath = wp_get_original_image_path( $this->attachment->ID );
 		} else {
 			$this->fullsizepath = get_attached_file( $this->attachment->ID );

--- a/tests/test-regenerator.php
+++ b/tests/test-regenerator.php
@@ -113,7 +113,7 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 	public function test_missing_original_file() {
 		$this->attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
 
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
+		if ( function_exists( 'wp_get_original_image_path' ) && wp_attachment_is_image( $this->attachment_id ) ) {
 			unlink( wp_get_original_image_path( $this->attachment_id ) );
 		} else {
 			unlink( get_attached_file( $this->attachment_id ) );
@@ -130,7 +130,7 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 		$this->attachment_id = $this->helper_create_attachment();
 		$old_metadata        = wp_get_attachment_metadata( $this->attachment_id );
 
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
+		if ( function_exists( 'wp_get_original_image_path' ) && wp_attachment_is_image( $this->attachment_id ) ) {
 			$upload_dir = dirname( wp_get_original_image_path( $this->attachment_id ) ) . DIRECTORY_SEPARATOR;
 		} else {
 			$upload_dir = dirname( get_attached_file( $this->attachment_id ) ) . DIRECTORY_SEPARATOR;
@@ -270,7 +270,7 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 			'large'        => '33772-1024x576.jpg',
 		);
 
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
+		if ( function_exists( 'wp_get_original_image_path' ) && wp_attachment_is_image( $this->attachment_id ) ) {
 			$upload_dir = dirname( wp_get_original_image_path( $this->attachment_id ) ) . DIRECTORY_SEPARATOR;
 		} else {
 			$upload_dir = dirname( get_attached_file( $this->attachment_id ) ) . DIRECTORY_SEPARATOR;
@@ -330,7 +330,7 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'regenerate-thumbnails-test-inmeta', $old_metadata['sizes'] );
 		$this->assertArrayHasKey( 'regenerate-thumbnails-test-notinmeta', $old_metadata['sizes'] );
 
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
+		if ( function_exists( 'wp_get_original_image_path' ) && wp_attachment_is_image( $this->attachment_id ) ) {
 			$thumbnail_file_to_keep = wp_get_original_image_path( $attachment_to_keep_id );
 			$fullsize_image         = wp_get_original_image_path( $this->attachment_id );
 		} else {
@@ -348,7 +348,7 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 
 		// After this, "inmeta" will be in the meta and "notinmeta" will exist but not be in the meta
 		require_once( ABSPATH . 'wp-admin/includes/admin.php' );
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
+		if ( function_exists( 'wp_get_original_image_path' ) && wp_attachment_is_image( $this->attachment_id ) ) {
 			$step2_metadata = wp_generate_attachment_metadata( $this->attachment_id, wp_get_original_image_path( $this->attachment_id ) );
 		} else {
 			$step2_metadata = wp_generate_attachment_metadata( $this->attachment_id, get_attached_file( $this->attachment_id ) );
@@ -414,7 +414,7 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 			$thumbnails[ $size ] = $size_data['file'];
 		}
 
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
+		if ( function_exists( 'wp_get_original_image_path' ) && wp_attachment_is_image( $this->attachment_id ) ) {
 			$upload_dir = dirname( wp_get_original_image_path( $this->attachment_id ) ) . DIRECTORY_SEPARATOR;
 		} else {
 			$upload_dir = dirname( get_attached_file( $this->attachment_id ) ) . DIRECTORY_SEPARATOR;
@@ -499,7 +499,7 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 
 	public function helper_get_current_thumbnail_statuses() {
 		$attachment   = get_post( $this->attachment_id );
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
+		if ( function_exists( 'wp_get_original_image_path' ) && wp_attachment_is_image( $this->attachment_id ) ) {
 			$fullsizepath = wp_get_original_image_path( $this->attachment_id );
 		} else {
 			$fullsizepath = get_attached_file( $this->attachment_id );
@@ -612,7 +612,7 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 
 		$this->attachment_id = $this->helper_create_upload_object_utf8( $test_file_path );
 
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
+		if ( function_exists( 'wp_get_original_image_path' ) && wp_attachment_is_image( $this->attachment_id ) ) {
 			$fullsizepath = wp_get_original_image_path( $this->attachment_id );
 		} else {
 			$fullsizepath = get_attached_file( $this->attachment_id );

--- a/tests/test-regenerator.php
+++ b/tests/test-regenerator.php
@@ -181,6 +181,14 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_get_fullsizepath_for_pdf() {
+		$test_pdf = DIR_TESTDATA . '/images/wordpress-gsoc-flyer.pdf';
+		$attachment_id = self::factory()->attachment->create_upload_object( $test_pdf );
+		$regenerator = RegenerateThumbnails_Regenerator::get_instance( $attachment_id );
+		$fullsizepath = $regenerator->get_fullsizepath();
+		$this->assertEquals( get_attached_file( $attachment_id ), $fullsizepath );
+	}
+
 	public function test_regenerate_thumbnails_for_pdf() {
 		$test_pdf = DIR_TESTDATA . '/images/wordpress-gsoc-flyer.pdf';
 
@@ -192,11 +200,7 @@ class Regenerate_Thumbnails_Tests_Regenerator extends WP_UnitTestCase {
 		$this->attachment_id = self::factory()->attachment->create_upload_object( $test_pdf );
 		$old_metadata        = wp_get_attachment_metadata( $this->attachment_id );
 
-		if ( function_exists( 'wp_get_original_image_path' ) ) {
-			$upload_dir = dirname( wp_get_original_image_path( $this->attachment_id ) ) . DIRECTORY_SEPARATOR;
-		} else {
-			$upload_dir = dirname( get_attached_file( $this->attachment_id ) ) . DIRECTORY_SEPARATOR;
-		}
+		$upload_dir = dirname( get_attached_file( $this->attachment_id ) ) . DIRECTORY_SEPARATOR;
 
 		$expected_default_thumbnail_sizes = array(
 			'thumbnail' => array( 116, 150 ),


### PR DESCRIPTION
When I try to regenerate the thumbnails of a PDF attachment I receive the following error message:
> The fullsize image file cannot be found in your uploads directory at . Without it, new thumbnail images can't be generated.

The error message is misleading as there is no issue with the fullsize attachment file.

https://github.com/Automattic/regenerate-thumbnails/blob/5a8b4317f233337a7bb6a50bdc3c3f55b63bdfe2/includes/class-regeneratethumbnails-regenerator.php#L131

The function call above evaluates to `false` if `wp_attachment_is_image($attachment_id)` evaluates to `false` (see why in the [WordPress reference](https://developer.wordpress.org/reference/functions/wp_get_original_image_path/)). So in particular when dealing with PDF attachments `wp_get_original_image_path($attachment_id, ...)` always evaluates to `false` and in turn triggers the `regenerate_thumbnails_regenerator_file_not_found` error with the message above.

I would suggest to use `get_attached_file( $this->attachment->ID )` as the `fullsizepath` when we are not dealing with an image attachment. This way PDF attachment thumbnails get regenerated as intended.

This issue has already been raised in #94.