### PR TITLE
Update readme.txt changelog with PHP 8.1 and 8.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,8 @@ This plugin does not log nor transmit any user data. Infact it doesn't even do a
 = Version 3.1.5 =
 
 * Fix: Don't overwrite 'All X Attachment' button label with featured images count.
+* Tested successfully with PHP 8.1.
+* Tested successfully with PHP 8.2.
 
 = Version 3.1.4 =
 


### PR DESCRIPTION
Fixes #137

See also https://wordpress.org/support/topic/regenerate-thumbnails-plugin-php-8-1-compatibility/ for context.