### PR TITLE
Release v1.3.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regenerate-thumbnails",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "A WordPress plugin for regenerating the thumbnails for one or more of your image uploads. Useful when changing their sizes or your theme.",
   "homepage": "https://alex.blog/wordpress-plugins/regenerate-thumbnails/",
   "author": "Alex Mills (Viper007Bond)",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Viper007Bond
 Tags: thumbnail, thumbnails, post thumbnail, post thumbnails
 Requires at least: 4.7
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 5.2.4
 Stable tag: 3.1.6
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: thumbnail, thumbnails, post thumbnail, post thumbnails
 Requires at least: 4.7
 Tested up to: 6.2
 Requires PHP: 5.2.4
-Stable tag: 3.1.5
+Stable tag: 3.1.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,6 +75,7 @@ This plugin does not log nor transmit any user data. Infact it doesn't even do a
 = Version 3.1.6 =
 
 * Fix: Respect "Skip regenerating existing correctly sized thumbnails" setting.
+* Fix: Don't delete all thumbnails when deleting old unregistered thumbnails size.
 
 = Version 3.1.5 =
 

--- a/regenerate-thumbnails.php
+++ b/regenerate-thumbnails.php
@@ -5,7 +5,7 @@
 Plugin Name:  Regenerate Thumbnails
 Description:  Regenerate the thumbnails for one or more of your image uploads. Useful when changing their sizes or your theme.
 Plugin URI:   https://alex.blog/wordpress-plugins/regenerate-thumbnails/
-Version:      3.1.5
+Version:      3.1.6
 Author:       Alex Mills (Viper007Bond)
 Author URI:   https://alex.blog/
 Text Domain:  regenerate-thumbnails
@@ -40,7 +40,7 @@ class RegenerateThumbnails {
 	 *
 	 * @var string
 	 */
-	public $version = '3.1.5';
+	public $version = '3.1.6';
 
 	/**
 	 * The menu ID of this plugin, as returned by add_management_page().


### PR DESCRIPTION
This release branch contains:
- Bump to 1.3.6 version.
- `readme.txt` update.
- Bump WP tested-up-to version to 6.3.