### PR TITLE
Simpler patch for issue 94 126: PDF images don't regenerate

### DIFF
--- a/includes/class-regeneratethumbnails-regenerator.php
+++ b/includes/class-regeneratethumbnails-regenerator.php
@@ -138,7 +138,8 @@ class RegenerateThumbnails_Regenerator {
 
 		if ( function_exists( 'wp_get_original_image_path' ) ) {
 			$this->fullsizepath = wp_get_original_image_path( $this->attachment->ID );
-		} else {
+		} 
+		if ( ! $this->fullsizepath ) {
 			$this->fullsizepath = get_attached_file( $this->attachment->ID );
 		}
 


### PR DESCRIPTION
This is a simple patch to resolve issue 94 and issue 126, so PDF images can be regenerated as needed.

Refs #94 #126

See https://wordpress.org/support/topic/patch-skips-pdf-attachments-fullsize-image-file-cannot-be-found/